### PR TITLE
Declare compatibility with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 matrix:
   allow_failures:
-    - php: 7.0
     - php: hhvm
 
 env:


### PR DESCRIPTION
In order to use Common in PhpSpreadsheet (https://github.com/PHPOffice/PhpSpreadsheet/issues/18), we'll have to guarantee a compatibility with latest PHP versions.