### PR TITLE
Assert zip adapters return values

### DIFF
--- a/src/Common/Adapter/Zip/PclZipAdapter.php
+++ b/src/Common/Adapter/Zip/PclZipAdapter.php
@@ -15,10 +15,6 @@ class PclZipAdapter implements ZipInterface
      */
     protected $tmpDir;
 
-    /**
-     * @param $filename
-     * @return $this
-     */
     public function open($filename)
     {
         $this->oPclZip = new PclZip($filename);
@@ -26,20 +22,11 @@ class PclZipAdapter implements ZipInterface
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function close()
     {
         return $this;
     }
 
-    /**
-     * @param $localname
-     * @param $contents
-     * @return $this
-     * @throws \Exception
-     */
     public function addFromString($localname, $contents)
     {
         $pathData = pathinfo($localname);

--- a/src/Common/Adapter/Zip/ZipArchiveAdapter.php
+++ b/src/Common/Adapter/Zip/ZipArchiveAdapter.php
@@ -16,11 +16,6 @@ class ZipArchiveAdapter implements ZipInterface
      */
     protected $filename;
 
-    /**
-     * @param string $filename
-     * @throws \Exception Could not open $this->filename for writing.
-     * @return mixed
-     */
     public function open($filename)
     {
         $this->filename = $filename;
@@ -35,10 +30,6 @@ class ZipArchiveAdapter implements ZipInterface
         throw new \Exception("Could not open $this->filename for writing.");
     }
 
-    /**
-     * @return $this
-     * @throws \Exception Could not close zip file $this->filename.
-     */
     public function close()
     {
         if ($this->oZipArchive->close() === false) {
@@ -47,13 +38,12 @@ class ZipArchiveAdapter implements ZipInterface
         return $this;
     }
 
-    /**
-     * @param $localname
-     * @param $contents
-     * @return bool
-     */
     public function addFromString($localname, $contents)
     {
-        return $this->oZipArchive->addFromString($localname, $contents);
+        if ($this->oZipArchive->addFromString($localname, $contents) === false) {
+            throw new \Exception("Error zipping files : " . $localname);
+        }
+
+        return $this;
     }
 }

--- a/src/Common/Adapter/Zip/ZipInterface.php
+++ b/src/Common/Adapter/Zip/ZipInterface.php
@@ -4,7 +4,27 @@ namespace PhpOffice\Common\Adapter\Zip;
 
 interface ZipInterface
 {
+    /**
+     * Open a ZIP file archive
+     * @param string $filename
+     * @return $this
+     * @throws \Exception
+     */
     public function open($filename);
+
+    /**
+     * Close the active archive (opened or newly created)
+     * @return $this
+     * @throws \Exception
+     */
     public function close();
+
+    /**
+     * Add a file to a ZIP archive using its contents
+     * @param string $localname The name of the entry to create.
+     * @param string $contents The contents to use to create the entry. It is used in a binary safe mode.
+     * @return $this
+     * @throws \Exception
+     */
     public function addFromString($localname, $contents);
 }

--- a/tests/Common/Tests/Adapter/Zip/AbstractZipAdapterTest.php
+++ b/tests/Common/Tests/Adapter/Zip/AbstractZipAdapterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Common\Tests\Adapter\Zip;
+
+use PhpOffice\Common\Tests\TestHelperZip;
+
+abstract class AbstractZipAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    protected $zipTest;
+
+    /**
+     * Returns a new instance of the adapter to test
+     * @return \PhpOffice\Common\Adapter\Zip\ZipInterface
+     */
+    abstract protected function createAdapter();
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $pathResources = PHPOFFICE_COMMON_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'files'.DIRECTORY_SEPARATOR;
+        $this->zipTest = tempnam(sys_get_temp_dir(), 'PhpOfficeCommon');
+        copy($pathResources.'Sample_01_Simple.pptx', $this->zipTest);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        if (is_file($this->zipTest)) {
+            unlink($this->zipTest);
+        }
+    }
+
+    public function testOpen()
+    {
+        $adapter = $this->createAdapter();
+        $this->assertSame($adapter, $adapter->open($this->zipTest));
+    }
+
+    public function testClose()
+    {
+        $adapter = $this->createAdapter();
+        $adapter->open($this->zipTest);
+        $this->assertSame($adapter, $adapter->close());
+    }
+
+    public function testAddFromString()
+    {
+        $expectedPath = 'file.test';
+        $expectedContent = 'Content';
+
+        $adapter = $this->createAdapter();
+        $adapter->open($this->zipTest);
+        $this->assertSame($adapter, $adapter->addFromString($expectedPath, $expectedContent));
+        $adapter->close();
+
+        $this->assertTrue(TestHelperZip::assertFileExists($this->zipTest, $expectedPath));
+        $this->assertTrue(TestHelperZip::assertFileContent($this->zipTest, $expectedPath, $expectedContent));
+    }
+}

--- a/tests/Common/Tests/Adapter/Zip/PclZipAdapterTest.php
+++ b/tests/Common/Tests/Adapter/Zip/PclZipAdapterTest.php
@@ -5,50 +5,10 @@ namespace Common\Tests\Adapter\Zip;
 use PhpOffice\Common\Adapter\Zip\PclZipAdapter;
 use PhpOffice\Common\Tests\TestHelperZip;
 
-class PclZipAdapterTest extends \PHPUnit_Framework_TestCase
+class PclZipAdapterTest extends AbstractZipAdapterTest
 {
-    protected $zipTest;
-
-    public function setUp()
+    protected function createAdapter()
     {
-        parent::setUp();
-
-        $pathResources = PHPOFFICE_COMMON_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'files'.DIRECTORY_SEPARATOR;
-        $this->zipTest = tempnam($pathResources, 'PhpOfficeCommon');
-        copy($pathResources.'Sample_01_Simple.pptx', $this->zipTest);
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        unlink($this->zipTest);
-    }
-
-    public function testOpen()
-    {
-        $object = new PclZipAdapter();
-        $this->assertInstanceOf('PhpOffice\\Common\\Adapter\\Zip\\ZipInterface', $object->open($this->zipTest));
-    }
-
-    public function testClose()
-    {
-        $object = new PclZipAdapter();
-        $object->open($this->zipTest);
-        $this->assertInstanceOf('PhpOffice\\Common\\Adapter\\Zip\\ZipInterface', $object->close());
-    }
-
-    public function testAddFromString()
-    {
-        $expectedPath = 'file.test';
-        $expectedContent = 'Content';
-
-        $object = new PclZipAdapter();
-        $object->open($this->zipTest);
-        $object->addFromString($expectedPath, $expectedContent);
-        $object->close();
-
-        $this->assertTrue(TestHelperZip::assertFileExists($this->zipTest, $expectedPath));
-        $this->assertTrue(TestHelperZip::assertFileContent($this->zipTest, $expectedPath, $expectedContent));
+        return new PclZipAdapter();
     }
 }

--- a/tests/Common/Tests/Adapter/Zip/ZipArchiveAdapterTest.php
+++ b/tests/Common/Tests/Adapter/Zip/ZipArchiveAdapterTest.php
@@ -5,52 +5,10 @@ namespace Common\Tests\Adapter\Zip;
 use PhpOffice\Common\Adapter\Zip\ZipArchiveAdapter;
 use PhpOffice\Common\Tests\TestHelperZip;
 
-class ZipArchiveAdapterTest extends \PHPUnit_Framework_TestCase
+class ZipArchiveAdapterTest extends AbstractZipAdapterTest
 {
-    protected $zipTest;
-
-    public function setUp()
+    protected function createAdapter()
     {
-        parent::setUp();
-
-        $pathResources = PHPOFFICE_COMMON_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'files'.DIRECTORY_SEPARATOR;
-        $this->zipTest = tempnam($pathResources, 'PhpOfficeCommon');
-        copy($pathResources.'Sample_01_Simple.pptx', $this->zipTest);
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        if (is_file($this->zipTest)) {
-            unlink($this->zipTest);
-        }
-    }
-
-    public function testOpen()
-    {
-        $object = new ZipArchiveAdapter();
-        $this->assertInstanceOf('PhpOffice\\Common\\Adapter\\Zip\\ZipInterface', $object->open($this->zipTest));
-    }
-
-    public function testClose()
-    {
-        $object = new ZipArchiveAdapter();
-        $object->open($this->zipTest);
-        $this->assertInstanceOf('PhpOffice\\Common\\Adapter\\Zip\\ZipInterface', $object->close());
-    }
-
-    public function testAddFromString()
-    {
-        $expectedPath = 'file.test';
-        $expectedContent = 'Content';
-
-        $object = new ZipArchiveAdapter();
-        $object->open($this->zipTest);
-        $object->addFromString($expectedPath, $expectedContent);
-        $object->close();
-
-        $this->assertTrue(TestHelperZip::assertFileExists($this->zipTest, $expectedPath));
-        $this->assertTrue(TestHelperZip::assertFileContent($this->zipTest, $expectedPath, $expectedContent));
+        return new ZipArchiveAdapter();
     }
 }


### PR DESCRIPTION
Unit tests did not properly tests that both adapters had the exact
same behavior for returned values. By using common code for testing
we can assert that the behavior is now in fact identical.

Also phpdocs were moved to the interface itself instead of each
adapters.