### PR TITLE
Write attribute's value of type float independently of locale

### DIFF
--- a/src/Common/XMLWriter.php
+++ b/src/Common/XMLWriter.php
@@ -27,7 +27,6 @@ namespace PhpOffice\Common;
  * @method bool startDocument(string $version = 1.0, string $encoding = null, string $standalone = null)
  * @method bool startElement(string $name)
  * @method bool text(string $content)
- * @method bool writeAttribute(string $name, mixed $value)
  * @method bool writeCData(string $content)
  * @method bool writeComment(string $content)
  * @method bool writeElement(string $name, string $content = null)
@@ -166,5 +165,18 @@ class XMLWriter extends \XMLWriter
         if ($condition == true) {
             $this->writeAttribute($attribute, $value);
         }
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     * @return bool
+     */
+    public function writeAttribute($name, $value)
+    {
+        if (is_float($value)) {
+            $value = json_encode($value);
+        }
+        return parent::writeAttribute($name, $value);
     }
 }

--- a/tests/Common/Tests/XMLWriterTest.php
+++ b/tests/Common/Tests/XMLWriterTest.php
@@ -43,4 +43,29 @@ class XMLWriterTest extends \PHPUnit_Framework_TestCase
         $object->endElement();
         $this->assertEquals('<element>BBB</element>'.chr(10), $object->getData());
     }
+
+    public function testWriteAttribute()
+    {
+        $xmlWriter = new XMLWriter();
+        $xmlWriter->startElement('element');
+        $xmlWriter->writeAttribute('name', 'value');
+        $xmlWriter->endElement();
+
+        $this->assertSame('<element name="value"/>' . chr(10), $xmlWriter->getData());
+    }
+
+    public function testWriteAttributeShouldWriteFloatValueLocaleIndependent()
+    {
+        $value = 1.2;
+
+        $xmlWriter = new XMLWriter();
+        $xmlWriter->startElement('element');
+        $xmlWriter->writeAttribute('name', $value);
+        $xmlWriter->endElement();
+
+        setlocale(LC_NUMERIC, 'de');
+
+        $this->assertSame('1,2', (string)$value);
+        $this->assertSame('<element name="1.2"/>' . chr(10), $xmlWriter->getData());
+    }
 }

--- a/tests/Common/Tests/XMLWriterTest.php
+++ b/tests/Common/Tests/XMLWriterTest.php
@@ -63,7 +63,7 @@ class XMLWriterTest extends \PHPUnit_Framework_TestCase
         $xmlWriter->writeAttribute('name', $value);
         $xmlWriter->endElement();
 
-        setlocale(LC_NUMERIC, 'de');
+        setlocale(LC_NUMERIC, 'de_DE.UTF-8', 'de');
 
         $this->assertSame('1,2', (string)$value);
         $this->assertSame('<element name="1.2"/>' . chr(10), $xmlWriter->getData());


### PR DESCRIPTION
This should fix https://github.com/PHPOffice/PHPWord/issues/1268