### PR TITLE
Remove leading slash when required

### DIFF
--- a/src/Common/XMLReader.php
+++ b/src/Common/XMLReader.php
@@ -54,6 +54,12 @@ class XMLReader
         $zip = new \ZipArchive();
         $zip->open($zipFile);
         $content = $zip->getFromName($xmlFile);
+
+        // Files downloaded from Sharepoint are somehow different and fail on the leading slash.
+        if ($content === false && substr($xmlFile, 0, 1) === '/') {
+            $content = $zip->getFromName(substr($xmlFile, 1));
+        }
+
         $zip->close();
 
         if ($content === false) {


### PR DESCRIPTION
We were trying to open Word files downloaded from Sharepoint. For some reason, those zip files work a bit differently. When a trailing slash was added ("/word/document2.xml"), it failed. When I removed the trailing slash ("word/document2.xml"), it opened without any issue.

To fix this, I added a check if there is content. If not, try without slash.