### PR TITLE
Ensure that library re-sets original xml entity loading value after d…

### DIFF
--- a/src/Common/XMLReader.php
+++ b/src/Common/XMLReader.php
@@ -71,10 +71,11 @@ class XMLReader
      */
     public function getDomFromString($content)
     {
+        $originalLibXMLEntityValue = libxml_disable_entity_loader();
         libxml_disable_entity_loader(true);
         $this->dom = new \DOMDocument();
         $this->dom->loadXML($content);
-
+        libxml_disable_entity_loader($originalLibXMLEntityValue);
         return $this->dom;
     }
 


### PR DESCRIPTION
…oing what is needed

I contribute to another project CiviCRM which uses this library. We have found the most recent versions have been messing with our unit tests as we load in xml files in the tests. This is because the library affects the global value of libxml_disable_entity_loader without re-setting it after it has completed its work.