### PR TITLE
Compatibility Changes for PHP8 and Newer Releases of PhpUnit

### DIFF
--- a/src/Common/XMLReader.php
+++ b/src/Common/XMLReader.php
@@ -64,6 +64,17 @@ class XMLReader
     }
 
     /**
+     * Call libxml_disable_entity_loader, but only for PHP < 8
+     *
+     * @param bool $value
+     * @return bool
+     */
+    public static function libxml_disable($value)
+    {
+        return version_compare(PHP_VERSION, '8') < 0 && libxml_disable_entity_loader($value);
+    }
+
+    /**
      * Get DOMDocument from content string
      *
      * @param string $content
@@ -71,10 +82,10 @@ class XMLReader
      */
     public function getDomFromString($content)
     {
-        $originalLibXMLEntityValue = libxml_disable_entity_loader(true);
+        $originalLibXMLEntityValue = self::libxml_disable(true);
         $this->dom = new \DOMDocument();
         $this->dom->loadXML($content);
-        libxml_disable_entity_loader($originalLibXMLEntityValue);
+        self::libxml_disable($originalLibXMLEntityValue);
 
         return $this->dom;
     }

--- a/src/Common/XMLReader.php
+++ b/src/Common/XMLReader.php
@@ -69,7 +69,7 @@ class XMLReader
      * @param bool $value
      * @return bool
      */
-    public static function libxml_disable($value)
+    public static function libxmlDisable($value)
     {
         return version_compare(PHP_VERSION, '8') < 0 && libxml_disable_entity_loader($value);
     }
@@ -82,10 +82,10 @@ class XMLReader
      */
     public function getDomFromString($content)
     {
-        $originalLibXMLEntityValue = self::libxml_disable(true);
+        $originalLibXMLEntityValue = self::libxmlDisable(true);
         $this->dom = new \DOMDocument();
         $this->dom->loadXML($content);
-        self::libxml_disable($originalLibXMLEntityValue);
+        self::libxmlDisable($originalLibXMLEntityValue);
 
         return $this->dom;
     }

--- a/src/Common/XMLWriter.php
+++ b/src/Common/XMLWriter.php
@@ -86,7 +86,7 @@ class XMLWriter extends \XMLWriter
         if (empty($this->tempFileName)) {
             return;
         }
-        if (PHP_OS != 'WINNT' && @unlink($this->tempFileName) === false) {
+        if ((version_compare(PHP_VERSION, '7.3') >= 0 || PHP_OS != 'WINNT') && @unlink($this->tempFileName) === false) {
             throw new \Exception('The file '.$this->tempFileName.' could not be deleted.');
         }
     }
@@ -166,18 +166,5 @@ class XMLWriter extends \XMLWriter
         if ($condition == true) {
             $this->writeAttribute($attribute, $value);
         }
-    }
-
-    /**
-     * @param string $name
-     * @param mixed $value
-     * @return bool
-     */
-    public function writeAttribute($name, $value)
-    {
-        if (is_float($value)) {
-            $value = json_encode($value);
-        }
-        return parent::writeAttribute($name, $value);
     }
 }

--- a/tests/Common/Tests/DrawingTest.php
+++ b/tests/Common/Tests/DrawingTest.php
@@ -115,7 +115,11 @@ class DrawingTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(Drawing::htmlToRGB('0000'));
         $this->assertFalse(Drawing::htmlToRGB('00000'));
 
-        $this->assertInternalType('array', Drawing::htmlToRGB('ABCDEF'));
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray(Drawing::htmlToRGB('ABCDEF'));
+        } else {
+            $this->assertInternalType('array', Drawing::htmlToRGB('ABCDEF'));
+        }
         $this->assertCount(3, Drawing::htmlToRGB('ABCDEF'));
         $this->assertEquals(array(0xAB, 0xCD, 0xEF), Drawing::htmlToRGB('ABCDEF'));
         $this->assertEquals(array(0xAB, 0xCD, 0xEF), Drawing::htmlToRGB('#ABCDEF'));

--- a/tests/Common/Tests/FileTest.php
+++ b/tests/Common/Tests/FileTest.php
@@ -42,9 +42,14 @@ class FileTest extends \PHPUnit\Framework\TestCase
     public function testGetFileContents()
     {
         $pathResources = PHPOFFICE_COMMON_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR;
-        $this->assertInternalType('string', File::fileGetContents($pathResources.'images'.DIRECTORY_SEPARATOR.'PHPPowerPointLogo.png'));
         $this->assertFalse(File::fileGetContents($pathResources.'images'.DIRECTORY_SEPARATOR.'PHPPowerPointLogo_404.png'));
-        $this->assertInternalType('string', File::fileGetContents('zip://'.$pathResources.'files'.DIRECTORY_SEPARATOR.'Sample_01_Simple.pptx#[Content_Types].xml'));
+        if (method_exists($this, 'assertIsString')) {
+            $this->assertIsString(File::fileGetContents($pathResources.'images'.DIRECTORY_SEPARATOR.'PHPPowerPointLogo.png'));
+            $this->assertIsString(File::fileGetContents('zip://'.$pathResources.'files'.DIRECTORY_SEPARATOR.'Sample_01_Simple.pptx#[Content_Types].xml'));
+        } else {
+            $this->assertInternalType('string', File::fileGetContents($pathResources.'images'.DIRECTORY_SEPARATOR.'PHPPowerPointLogo.png'));
+            $this->assertInternalType('string', File::fileGetContents('zip://'.$pathResources.'files'.DIRECTORY_SEPARATOR.'Sample_01_Simple.pptx#[Content_Types].xml'));
+        }
         $this->assertFalse(File::fileGetContents('zip://'.$pathResources.'files'.DIRECTORY_SEPARATOR.'Sample_01_Simple.pptx#404.xml'));
         $this->assertFalse(File::fileGetContents('zip://'.$pathResources.'files'.DIRECTORY_SEPARATOR.'404.pptx#404.xml'));
     }

--- a/tests/Common/Tests/XMLReaderTest.php
+++ b/tests/Common/Tests/XMLReaderTest.php
@@ -58,10 +58,14 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test that read from non existing archive throws exception
      *
-     * @expectedException Exception
      */
     public function testThrowsExceptionOnNonExistingArchive()
     {
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Exception');
+        } else {
+            $this->setExpectedException('Exception');
+        }
         $pathResources = PHPOFFICE_COMMON_TESTS_BASE_DIR.DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'files'.DIRECTORY_SEPARATOR;
 
         $reader = new XMLReader();
@@ -125,10 +129,14 @@ class XMLReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test that xpath fails if custom namespace is not registered
      *
-     * @expectedException InvalidArgumentException
      */
     public function testShouldThowExceptionIfTryingToRegisterNamespaceBeforeReadingDoc()
     {
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('InvalidArgumentException');
+        } else {
+            $this->setExpectedException('InvalidArgumentException');
+        }
         $reader = new XMLReader();
         $reader->registerNamespace('test', 'http://phpword.com/my/custom/namespace');
     }

--- a/tests/Common/Tests/XMLWriterTest.php
+++ b/tests/Common/Tests/XMLWriterTest.php
@@ -54,6 +54,45 @@ class XMLWriterTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('<element name="value"/>' . chr(10), $xmlWriter->getData());
     }
 
+    public function testWriteAttributeIf()
+    {
+        $xmlWriter = new XMLWriter();
+        $xmlWriter->startElement('element');
+        $xmlWriter->writeAttributeIf(true, 'trueAttr', '1');
+        $xmlWriter->writeAttributeIf(false, 'falseAttr', '0');
+        $xmlWriter->endElement();
+
+        $this->assertSame('<element trueAttr="1"/>' . chr(10), $xmlWriter->getData());
+    }
+
+    public function testWriteElementIf()
+    {
+        $xmlWriter = new XMLWriter();
+        $xmlWriter->writeElementIf(true, 'trueElement', null, '1');
+        $xmlWriter->writeElementIf(false, 'falseElement', null, '0');
+        $xmlWriter->writeElementIf(true, 'trueElementAttr', 'trueAttr', '2');
+        $xmlWriter->writeElementIf(false, 'falseElementAttr', 'falseAttr', '0');
+
+        $this->assertSame('<trueElement>1</trueElement>' . chr(10)
+            . '<trueElementAttr trueAttr="2"/>' . chr(10), $xmlWriter->getData());
+    }
+
+    public function testWriteElementBlockString()
+    {
+        $xmlWriter = new XMLWriter();
+        $xmlWriter->writeElementBlock('element', 'name', 'value');
+
+        $this->assertSame('<element name="value"/>' . chr(10), $xmlWriter->getData());
+    }
+
+    public function testWriteElementBlockArray()
+    {
+        $xmlWriter = new XMLWriter();
+        $xmlWriter->writeElementBlock('element', array('name1' => 'value1', 'name2' => 'value2'));
+
+        $this->assertSame('<element name1="value1" name2="value2"/>' . chr(10), $xmlWriter->getData());
+    }
+
     public function testWriteAttributeShouldWriteFloatValueLocaleIndependent()
     {
         $value = 1.2;
@@ -65,7 +104,33 @@ class XMLWriterTest extends \PHPUnit\Framework\TestCase
 
         setlocale(LC_NUMERIC, 'de_DE.UTF-8', 'de');
 
-        $this->assertSame('1,2', (string)$value);
+        $this->assertSame((version_compare(PHP_VERSION, 8) < 0) ? '1,2' : '1.2', (string)$value);
         $this->assertSame('<element name="1.2"/>' . chr(10), $xmlWriter->getData());
+    }
+
+    public function testCompatibilityTrue()
+    {
+        $xmlWriter = new XMLWriter(\PhpOffice\Common\XMLWriter::STORAGE_MEMORY, null, true);
+        $xmlWriter->startElement('element1');
+        $xmlWriter->startElement('element2');
+        $xmlWriter->endElement();
+        $xmlWriter->endElement();
+
+        $this->assertSame('<element1>'
+            . '<element2/>'
+            . '</element1>', $xmlWriter->getData());
+    }
+
+    public function testCompatibilityFalse()
+    {
+        $xmlWriter = new XMLWriter(\PhpOffice\Common\XMLWriter::STORAGE_MEMORY, null, false);
+        $xmlWriter->startElement('element1');
+        $xmlWriter->startElement('element2');
+        $xmlWriter->endElement();
+        $xmlWriter->endElement();
+
+        $this->assertSame('<element1>' . chr(10)
+            . '  <element2/>' . chr(10)
+            . '</element1>' . chr(10), $xmlWriter->getData());
     }
 }


### PR DESCRIPTION
XMLReader - do not call libxml_disable_entity_loader for PHP8+
XMLWriter - 1. delete temporary files on Windows for PHP7.3+ (there had
  been a problem with unlink on Windows before then).
            2. Eliminate unneeded writeAttribute (tested against PhpWord
              as well as Common without any issues). Current code was
              a problem with newer PhpUnit.
DrawingTest - assertIsArray, when available, in lieu of assertInternalType
FileTest - assertIsString, when available, in lieu of assertInternalType
XMLReaderTest - expect exceptions in code, not DocBlock.
XMLWriterTest - 1. PHP8 ignores locale when converting float to string.
                   This is also a problem for PhpSpreadsheet.
                2. Added some tests to improve coverage.