### PR TITLE
Fix Drawing pixelsToPoints and twipsToPixels ratios

### DIFF
--- a/src/Common/Drawing.php
+++ b/src/Common/Drawing.php
@@ -56,7 +56,7 @@ class Drawing
      */
     public static function pixelsToPoints($pValue = 0)
     {
-        return $pValue * 0.67777777;
+        return $pValue * 0.75;
     }
 
     /**
@@ -70,7 +70,7 @@ class Drawing
         if ($pValue == 0) {
             return 0;
         }
-        return ((($pValue * 1.333333333) / self::DPI_96) * 2.54);
+        return ((($pValue / 0.75) / self::DPI_96) * 2.54);
     }
     
     /**
@@ -84,7 +84,7 @@ class Drawing
         if ($pValue == 0) {
             return 0;
         }
-        return $pValue * 1.333333333;
+        return $pValue / 0.75;
     }
 
     /**
@@ -205,7 +205,7 @@ class Drawing
         if ($pValue == 0) {
             return 0;
         }
-        return round($pValue / 15.873984);
+        return round($pValue / 15);
     }
 
     /**

--- a/tests/Common/Tests/DrawingTest.php
+++ b/tests/Common/Tests/DrawingTest.php
@@ -68,9 +68,9 @@ class DrawingTest extends \PHPUnit\Framework\TestCase
         $value = rand(1, 100);
 
         $this->assertEquals(0, Drawing::pixelsToPoints());
-        $this->assertEquals($value*0.67777777, Drawing::pixelsToPoints($value));
+        $this->assertEquals($value*0.75, Drawing::pixelsToPoints($value));
         $this->assertEquals(0, Drawing::pointsToPixels());
-        $this->assertEquals($value* 1.333333333, Drawing::pointsToPixels($value));
+        $this->assertEquals($value/ 0.75, Drawing::pointsToPixels($value));
     }
 
     /**
@@ -80,7 +80,7 @@ class DrawingTest extends \PHPUnit\Framework\TestCase
         $value = rand(1, 100);
 
         $this->assertEquals(0, Drawing::pointsToCentimeters());
-        $this->assertEquals($value * 1.333333333 / Drawing::DPI_96 * 2.54, Drawing::pointsToCentimeters($value));
+        $this->assertEquals($value / 0.75 / Drawing::DPI_96 * 2.54, Drawing::pointsToCentimeters($value));
     }
 
     /**
@@ -105,7 +105,7 @@ class DrawingTest extends \PHPUnit\Framework\TestCase
 
         // Pixels
         $this->assertEquals(0, Drawing::twipsToPixels());
-        $this->assertEquals(round($value / 15.873984), Drawing::twipsToPixels($value));
+        $this->assertEquals(round($value / 15), Drawing::twipsToPixels($value));
     }
 
     public function testHTML()


### PR DESCRIPTION
For `pixelsToPoints` ("0.67777777", "1.333333333" and 0.75): Refs https://github.com/PHPOffice/PhpSpreadsheet/pull/1733
For `twipsToPixels`: 20 * 72/96 = 15, not "15.873984"