### PR TITLE
Add PHP 8.5 to the CI matrix

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
         -   name: Setup PHP
             uses: shivammathur/setup-php@v2
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       -   name: Setup PHP
           uses: shivammathur/setup-php@v2

--- a/src/Common/Autoloader.php
+++ b/src/Common/Autoloader.php
@@ -23,7 +23,7 @@ namespace PhpOffice\Common;
  */
 class Autoloader
 {
-    /** @const string */
+    /** @var string */
     public const NAMESPACE_PREFIX = 'PhpOffice\\Common\\';
 
     /**


### PR DESCRIPTION
- Add `8.5` to the `phpstan` and `phpunit` matrices.
- Fix php-cs-fixer finding in `src/Common/Autoloader.php` (`@const` → `@var`).