### PR TITLE
Allow PHPStan 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": ">=7",
         "phpmd/phpmd": "2.*",
-        "phpstan/phpstan": "^0.12.88 || ^1.0.0"
+        "phpstan/phpstan": "^0.12.88 || ^1.0.0 || ^2.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Common/Text.php
+++ b/src/Common/Text.php
@@ -133,7 +133,7 @@ class Text
      */
     public static function isUTF8(string $value = ''): bool
     {
-        return is_string($value) && ($value === '' || preg_match('/^./su', $value) == 1);
+        return $value === '' || preg_match('/^./su', $value) == 1;
     }
 
     /**


### PR DESCRIPTION
This allows PHPStan 2.x, so static analysis can run on PHP 8.4 and 8.5.
